### PR TITLE
Fix incorrect application of factors in raster.resample

### DIFF
--- a/greenwich/raster.py
+++ b/greenwich/raster.py
@@ -50,7 +50,7 @@ def geom_to_array(geom, size, affine):
     draw = ImageDraw.Draw(img)
     # MultiPolygon or Polygon with interior rings don't need another level of
     # nesting, but non-donut Polygons do.
-    if geom.GetGeometryCount() <= 1:
+    if geom.GetGeometryName == 'POLYGON' and geom.GetGeometryCount() <= 1:
         geom = [geom]
     for g in geom:
         if g.GetCoordinateDimension() > 2:

--- a/greenwich/raster.py
+++ b/greenwich/raster.py
@@ -577,8 +577,8 @@ class Raster(Comparable):
         factors = (size[0] / float(self.RasterXSize),
                    size[1] / float(self.RasterYSize))
         affine = AffineTransform(*tuple(self.affine))
-        affine.scale = (affine.scale[0] * factors[0],
-                        affine.scale[1] * factors[1])
+        affine.scale = (affine.scale[0] / factors[0],
+                        affine.scale[1] / factors[1])
         dest = self.new(size, affine)
         # Uses self and dest projection when set to None
         gdal.ReprojectImage(self.ds, dest.ds, None, None, interpolation)

--- a/greenwich/raster.py
+++ b/greenwich/raster.py
@@ -50,7 +50,7 @@ def geom_to_array(geom, size, affine):
     draw = ImageDraw.Draw(img)
     # MultiPolygon or Polygon with interior rings don't need another level of
     # nesting, but non-donut Polygons do.
-    if geom.GetGeometryName == 'POLYGON' and geom.GetGeometryCount() <= 1:
+    if geom.GetGeometryName() == 'POLYGON' and geom.GetGeometryCount() <= 1:
         geom = [geom]
     for g in geom:
         if g.GetCoordinateDimension() > 2:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -258,6 +258,10 @@ class RasterTestCase(RasterTestBase):
         size = tuple([i / 2 for i in self.ds.size])
         output = self.ds.resample(size)
         self.assertEqual(output.size, size)
+        input_geotransform = self.ds.GetGeoTransform()
+        output_geotransform = output.ds.GetGeoTransform()
+        self.assertEqual(input_geotransform[1] * 2, output_geotransform[1])
+        self.assertEqual(input_geotransform[5] * 2, output_geotransform[5])
 
     def test_new(self):
         dcopy = self.ds.new()


### PR DESCRIPTION
Hi Brian,

I discovered, that the re-sampling factor was incorrectly applied to new affine transformation in Raster.resample(). See extended test.

Once discovered it was an easy fix.

I discovered another issue (and created a simple patch). The condition in raster.py:53 generated invalid geometries for type Multipolygon if they only contained a single feature. 

I did not create test for this one yet.

Thanks for the good work,
Falk 